### PR TITLE
Allow retrieving PRs in any state combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ I am not sure where this project will go yet. For now, it fetches pull request a
 In the future, I think I want to add some analytics capabilities on top of this data and then maybe add a frontend in ScalaJS?
 
 ### TODO
-- Only refetch activity for PRs that have been updated since the last fetch
-- Allow retrieving prs in any state
-- Add some logging
+- [ ] Only refetch activity for PRs that have been updated since the last fetch
+- [x] Allow retrieving prs in any state
+- [ ] Add some logging

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -56,8 +56,8 @@ object Main extends ZIOAppDefault {
   private val app =
     for
       total <- CrawlingService.fetchPullRequestActivityAndSave(
-        PullRequestState.Merged,
-        RequestedCount.Fixed(10)
+        PullRequestState.default,
+        RequestedCount.Fixed(20)
       )
       _ <- Console.printLine(s"Total activities fetched: $total")
     yield ()

--- a/src/main/scala/client/BitBucketClientLive.scala
+++ b/src/main/scala/client/BitBucketClientLive.scala
@@ -53,7 +53,7 @@ private case class BitBucketClientLive(client: Client, config: BitbucketConfig)
     yield result._2.reverse
 
   override def listPullRequests(
-      state: PullRequestState,
+      state: Set[PullRequestState],
       count: RequestedCount
   ): ZIO[Scope, BitBucketApiError, List[PullRequestResponse]] =
     val url = s"$BASE_URL/pullrequests"
@@ -66,7 +66,10 @@ private case class BitBucketClientLive(client: Client, config: BitbucketConfig)
           pages.map(_.values.length).sum < target
 
     def makeRequest(url: String) =
-      makeBaseRequest(url).addQueryParam("state", state.asQueryParam)
+      makeBaseRequest(url).addQueryParam(
+        "state",
+        state.map(_.asQueryParam).mkString(",")
+      )
 
     for responses <- fetchUntil[BitBucketPullRequestResponse](
         url,

--- a/src/main/scala/client/BitbucketClient.scala
+++ b/src/main/scala/client/BitbucketClient.scala
@@ -13,7 +13,7 @@ import zio.*
 
 trait BitbucketClient:
   def listPullRequests(
-      state: PullRequestState,
+      state: Set[PullRequestState],
       count: RequestedCount
   ): ZIO[Scope, BitBucketApiError, List[PullRequestResponse]]
 
@@ -24,7 +24,10 @@ trait BitbucketClient:
   ]]
 
 object BitbucketClient:
-  def listPullRequests(state: PullRequestState, count: RequestedCount): ZIO[
+  def listPullRequests(
+      state: Set[PullRequestState],
+      count: RequestedCount
+  ): ZIO[
     BitbucketClient & Scope,
     BitBucketApiError,
     List[PullRequestResponse]

--- a/src/main/scala/model/response/pullrequest/PullRequestState.scala
+++ b/src/main/scala/model/response/pullrequest/PullRequestState.scala
@@ -1,14 +1,14 @@
 package org.treemage
 package model.response.pullrequest
 
-import zio.http.codec.QueryCodec
 import zio.schema.Schema
-import zio.schema.codec.BinaryCodec
 
 enum PullRequestState:
   case Open, Merged, Declined, Superseded
 
 object PullRequestState:
+  val default: Set[PullRequestState] = Set(Open, Merged)
+
   given Schema[PullRequestState] = Schema[String].transform(
     v => PullRequestState.valueOf(v.toLowerCase.capitalize),
     _.toString.toUpperCase

--- a/src/main/scala/service/CrawlingService.scala
+++ b/src/main/scala/service/CrawlingService.scala
@@ -14,13 +14,13 @@ enum CrawlingError:
 
 trait CrawlingService:
   def fetchPullRequestActivityAndSave(
-      state: PullRequestState,
+      state: Set[PullRequestState],
       count: RequestedCount
   ): ZIO[Scope, CrawlingError, Int]
 
 object CrawlingService:
   def fetchPullRequestActivityAndSave(
-      state: PullRequestState,
+      state: Set[PullRequestState],
       count: RequestedCount
   ): ZIO[Scope & CrawlingService, CrawlingError, Int] =
     for

--- a/src/main/scala/service/CrawlingServiceLive.scala
+++ b/src/main/scala/service/CrawlingServiceLive.scala
@@ -68,7 +68,7 @@ case class CrawlingServiceLive(
     yield activities.length
 
   override def fetchPullRequestActivityAndSave(
-      state: PullRequestState,
+      state: Set[PullRequestState],
       count: RequestedCount
   ): ZIO[Scope, CrawlingError, Int] =
     for


### PR DESCRIPTION
Change all method concerned with PRs to accept a `Set[PullRequestState]` to enable retrieving arbitrary combinations of PR states.